### PR TITLE
[CHORE] enhancing dashboard usage

### DIFF
--- a/pkg/api/v1/metric_usage.go
+++ b/pkg/api/v1/metric_usage.go
@@ -111,10 +111,16 @@ type RuleUsage struct {
 	Expression string `json:"expression"`
 }
 
+type DashboardUsage struct {
+	ID   string `json:"uid"`
+	Name string `json:"title"`
+	URL  string `json:"url"`
+}
+
 type MetricUsage struct {
-	Dashboards     Set[string]    `json:"dashboards,omitempty"`
-	RecordingRules Set[RuleUsage] `json:"recordingRules,omitempty"`
-	AlertRules     Set[RuleUsage] `json:"alertRules,omitempty"`
+	Dashboards     Set[DashboardUsage] `json:"dashboards,omitempty"`
+	RecordingRules Set[RuleUsage]      `json:"recordingRules,omitempty"`
+	AlertRules     Set[RuleUsage]      `json:"alertRules,omitempty"`
 }
 
 func MergeUsage(old, new *MetricUsage) *MetricUsage {

--- a/source/grafana/grafana.go
+++ b/source/grafana/grafana.go
@@ -144,10 +144,18 @@ func (c *grafanaCollector) generateUsage(metricNames modelAPIV1.Set[string], cur
 	dashboardURL := fmt.Sprintf("%s/d/%s", c.grafanaURL, currentDashboard.UID)
 	for metricName := range metricNames {
 		if usage, ok := metricUsage[metricName]; ok {
-			usage.Dashboards.Add(dashboardURL)
+			usage.Dashboards.Add(modelAPIV1.DashboardUsage{
+				ID:   currentDashboard.UID,
+				Name: currentDashboard.Title,
+				URL:  dashboardURL,
+			})
 		} else {
 			metricUsage[metricName] = &modelAPIV1.MetricUsage{
-				Dashboards: modelAPIV1.NewSet(dashboardURL),
+				Dashboards: modelAPIV1.NewSet(modelAPIV1.DashboardUsage{
+					ID:   currentDashboard.UID,
+					Name: currentDashboard.Title,
+					URL:  dashboardURL,
+				}),
 			}
 		}
 	}

--- a/source/perses/perses.go
+++ b/source/perses/perses.go
@@ -90,10 +90,18 @@ func (c *persesCollector) generateUsage(metricNames modelAPIV1.Set[string], curr
 	dashboardURL := fmt.Sprintf("%s/api/v1/projects/%s/dashboards/%s", c.persesURL, currentDashboard.Metadata.Project, currentDashboard.Metadata.Name)
 	for metricName := range metricNames {
 		if usage, ok := metricUsage[metricName]; ok {
-			usage.Dashboards.Add(dashboardURL)
+			usage.Dashboards.Add(modelAPIV1.DashboardUsage{
+				ID:   fmt.Sprintf("%s/%s", currentDashboard.Metadata.Project, currentDashboard.Metadata.Name),
+				Name: currentDashboard.Metadata.Name,
+				URL:  dashboardURL,
+			})
 		} else {
 			metricUsage[metricName] = &modelAPIV1.MetricUsage{
-				Dashboards: modelAPIV1.NewSet(dashboardURL),
+				Dashboards: modelAPIV1.NewSet(modelAPIV1.DashboardUsage{
+					ID:   fmt.Sprintf("%s/%s", currentDashboard.Metadata.Project, currentDashboard.Metadata.Name),
+					Name: currentDashboard.Metadata.Name,
+					URL:  dashboardURL,
+				}),
 			}
 		}
 	}


### PR DESCRIPTION
This pull request includes changes to improve the handling of dashboard usage information in the metric usage data structure. The most important changes involve adding a new `DashboardUsage` type and updating the `MetricUsage` structure to use this new type.

Improvements to data structures:

* [`pkg/api/v1/metric_usage.go`](diffhunk://#diff-4f7521578ba95a679cef599a9fa936b4cbe7b7a41e97c803e80d066f70081d4cR114-R121): Added a new `DashboardUsage` type with fields for `UID`, `Name`, and `URL`. Updated the `MetricUsage` structure to use a set of `DashboardUsage` instead of a set of strings for dashboards.

Updates to usage generation functions:

* [`source/grafana/grafana.go`](diffhunk://#diff-7cb9b8202d46fe4410e8efca5166abd45741a5ebfed0215dc16991741d38dcdcL147-R158): Modified the `generateUsage` function to create and add `DashboardUsage` objects instead of just URLs for Grafana dashboards.
* [`source/perses/perses.go`](diffhunk://#diff-4ed4f3959a96b98ffb9a38d74c074675c6918197d9d178c05a52ccfefb1698f6L93-R104): Modified the `generateUsage` function to create and add `DashboardUsage` objects instead of just URLs for Perses dashboards.