### PR TITLE
Improve matching regexp to avoid situation where it matches everything

### DIFF
--- a/database/database_test.go
+++ b/database/database_test.go
@@ -66,3 +66,12 @@ func TestGenerateRegexp(t *testing.T) {
 		})
 	}
 }
+
+func TestIsMatching(t *testing.T) {
+	re, _ := generateRegexp("foo|")
+	assert.False(t, isMatching(re, "bar"))
+	assert.True(t, isMatching(re, "foo"))
+
+	re, _ = generateRegexp("foo|bar")
+	assert.True(t, isMatching(re, "bar"))
+}


### PR DESCRIPTION
with @AntoineThebaud we saw in production that a regexp like `foo|` is matching every metric because `re.MatchString` is returning true.

This PR aims to avoid this situation by adding a check on what is matching. If only empty string is matching, then the new function implemented `isMatching` return false.

/cc @nicolastakashi 