### PR TITLE
[FEATURE] Add multiple filtering modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,12 @@ The tool provides an API endpoint, `/api/v1/metrics`, which returns the usage da
 
 You can use the following query parameter to filter the list returned:
 
-* **metric_name**: when used, it will trigger a fuzzy search on the metric_name based on the pattern provided.
+* **metric_name**: when used, it will trigger a fuzzy match search on the metric_name or exact/regex match if you enable it with `mode` parameter.
 * **used**: when used, will return only the metric used or not (depending on if you set this boolean to true or to false). Leave it empty if you want both.
-* **exact_match**: when used, it will trigger an exact match on the metric_name based on the pattern provided. This is useful when you want to search for a specific metric name.
+* **mode**: when used change mode for filtering metrics. Three values are available:
+  * **exact**: doing exact match (case sensitive) based on the metric name
+  * **fuzzy**: doing fuzzy match based on the metric name
+  * **regex**: doing regex match based on the metric name
 * **merge_partial_metrics**: when used, it will use the data from /api/v1/partial_metrics and merge them here.
 
 ### Partial Metrics

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ You can use the following query parameter to filter the list returned:
 
 * **metric_name**: when used, it will trigger a fuzzy search on the metric_name based on the pattern provided.
 * **used**: when used, will return only the metric used or not (depending on if you set this boolean to true or to false). Leave it empty if you want both.
+* **exact_match**: when used, it will trigger an exact match on the metric_name based on the pattern provided. This is useful when you want to search for a specific metric name.
 * **merge_partial_metrics**: when used, it will use the data from /api/v1/partial_metrics and merge them here.
 
 ### Partial Metrics

--- a/source/metric/endpoint.go
+++ b/source/metric/endpoint.go
@@ -16,6 +16,7 @@ package metric
 import (
 	"fmt"
 	"net/http"
+	"regexp"
 
 	"github.com/labstack/echo/v4"
 	"github.com/lithammer/fuzzysearch/fuzzy"
@@ -54,11 +55,37 @@ func (e *endpoint) GetMetric(ctx echo.Context) error {
 	return ctx.JSON(http.StatusOK, metric)
 }
 
+type Mode string
+
+const (
+	ExactMatch Mode = "exact"
+	FuzzyMatch Mode = "fuzzy"
+	RegexMatch Mode = "regex"
+)
+
 type request struct {
 	MetricName          string `query:"metric_name"`
+	Mode                Mode   `query:"mode"`
 	Used                *bool  `query:"used"`
-	ExactMatch          bool   `query:"exact_match"`
 	MergePartialMetrics bool   `query:"merge_partial_metrics"`
+}
+
+func isMetricMatching(metricName string, matchMode Mode, filter string) bool {
+	switch matchMode {
+	case ExactMatch:
+		return metricName == filter
+	case FuzzyMatch:
+		return fuzzy.Match(filter, metricName)
+	case RegexMatch:
+		re, err := regexp.Compile(filter)
+		if err != nil {
+			return false
+		}
+		return re.MatchString(metricName)
+	default:
+		// if no match mode is specified, we assume fuzzy match
+		return fuzzy.Match(filter, metricName)
+	}
 }
 
 func (r *request) filter(validMetricList map[string]*v1.Metric, partialMetricList map[string]*v1.PartialMetric) map[string]*v1.Metric {
@@ -78,7 +105,7 @@ func (r *request) filter(validMetricList map[string]*v1.Metric, partialMetricLis
 		return validMetricList
 	}
 	for k, v := range validMetricList {
-		if len(r.MetricName) == 0 || (r.ExactMatch && r.MetricName == k) || (!r.ExactMatch && fuzzy.Match(r.MetricName, k)) {
+		if len(r.MetricName) == 0 || isMetricMatching(k, r.Mode, r.MetricName) {
 			if r.Used == nil {
 				result[k] = v
 			} else if *r.Used && validMetricList[k].Usage != nil {
@@ -96,6 +123,9 @@ func (e *endpoint) ListMetrics(ctx echo.Context) error {
 	err := ctx.Bind(req)
 	if err != nil {
 		return ctx.JSON(http.StatusBadRequest, echo.Map{"message": err.Error()})
+	}
+	if req.Mode != "" && req.Mode != ExactMatch && req.Mode != FuzzyMatch && req.Mode != RegexMatch {
+		return ctx.JSON(http.StatusBadRequest, echo.Map{"message": fmt.Sprintf("invalid match mode: %s. Allowed: %s, %s or %s", req.Mode, ExactMatch, FuzzyMatch, RegexMatch)})
 	}
 	var partialMetricList map[string]*v1.PartialMetric
 	if req.MergePartialMetrics {

--- a/source/metric/endpoint.go
+++ b/source/metric/endpoint.go
@@ -57,6 +57,7 @@ func (e *endpoint) GetMetric(ctx echo.Context) error {
 type request struct {
 	MetricName          string `query:"metric_name"`
 	Used                *bool  `query:"used"`
+	ExactMatch          bool   `query:"exact_match"`
 	MergePartialMetrics bool   `query:"merge_partial_metrics"`
 }
 
@@ -77,7 +78,7 @@ func (r *request) filter(validMetricList map[string]*v1.Metric, partialMetricLis
 		return validMetricList
 	}
 	for k, v := range validMetricList {
-		if len(r.MetricName) == 0 || fuzzy.Match(r.MetricName, k) {
+		if len(r.MetricName) == 0 || (r.ExactMatch && r.MetricName == k) || (!r.ExactMatch && fuzzy.Match(r.MetricName, k)) {
 			if r.Used == nil {
 				result[k] = v
 			} else if *r.Used && validMetricList[k].Usage != nil {


### PR DESCRIPTION
Changing `/api/v1/metrics` endpoint logic:
- new param `mode`: allow to filter with exact match, fuzzy or regex

![image](https://github.com/user-attachments/assets/15a8db9f-78d6-450a-bcc4-480a1c31cf3e)
![image](https://github.com/user-attachments/assets/5a5d3f51-c6b6-47d2-b473-82c2f5209c9a)
![image](https://github.com/user-attachments/assets/1558ee09-891f-40ca-b7b6-9d684637d02c)
![image](https://github.com/user-attachments/assets/e4597950-66e0-4624-acad-c1120befa53d)

