### PR TITLE
[FEATURE] Allow collectors to use a custom url

### DIFF
--- a/config/collector.go
+++ b/config/collector.go
@@ -114,8 +114,9 @@ type RulesCollector struct {
 	MetricUsageClient *HTTPClient `yaml:"metric_usage_client,omitempty"`
 	// RetryToGetRules is the number of retries the collector will do to get the rules from Prometheus before actually failing.
 	// Between each retry, the collector will wait first 10 seconds, then 20 seconds, then 30 seconds ...etc.
-	RetryToGetRules uint       `yaml:"retry_to_get_rules,omitempty"`
-	HTTPClient      HTTPClient `yaml:"prometheus_client"`
+	RetryToGetRules uint        `yaml:"retry_to_get_rules,omitempty"`
+	HTTPClient      HTTPClient  `yaml:"prometheus_client"`
+	PublicURL       *common.URL `yaml:"public_url,omitempty"`
 }
 
 func (c *RulesCollector) Verify() error {
@@ -166,6 +167,7 @@ type PersesCollector struct {
 	Period            model.Duration          `yaml:"period,omitempty"`
 	MetricUsageClient *HTTPClient             `yaml:"metric_usage_client,omitempty"`
 	HTTPClient        config.RestConfigClient `yaml:"perses_client"`
+	PublicURL         *common.URL             `yaml:"public_url,omitempty"`
 }
 
 func (c *PersesCollector) Verify() error {
@@ -189,6 +191,7 @@ type GrafanaCollector struct {
 	Period            model.Duration `yaml:"period,omitempty"`
 	MetricUsageClient *HTTPClient    `yaml:"metric_usage_client,omitempty"`
 	HTTPClient        HTTPClient     `yaml:"grafana_client"`
+	PublicURL         *common.URL    `yaml:"public_url,omitempty"`
 }
 
 func (c *GrafanaCollector) Verify() error {

--- a/source/grafana/grafana.go
+++ b/source/grafana/grafana.go
@@ -34,10 +34,11 @@ import (
 
 func NewCollector(db database.Database, cfg config.GrafanaCollector) (async.SimpleTask, error) {
 	httpClient, err := config.NewHTTPClient(cfg.HTTPClient)
-	url := cfg.HTTPClient.URL.URL
 	if err != nil {
 		return nil, err
 	}
+	url := cfg.HTTPClient.URL.URL
+
 	var metricUsageClient client.Client
 	if cfg.MetricUsageClient != nil {
 		metricUsageClient, err = client.New(*cfg.MetricUsageClient)
@@ -53,6 +54,10 @@ func NewCollector(db database.Database, cfg config.GrafanaCollector) (async.Simp
 	}
 	grafanaClient := grafanaapi.NewHTTPClientWithConfig(strfmt.Default, transportConfig)
 	logger := logrus.StandardLogger().WithField("collector", "grafana")
+
+	if cfg.PublicURL != nil {
+		url = cfg.PublicURL.URL
+	}
 	return &grafanaCollector{
 		grafanaURL:    url.String(),
 		grafanaClient: grafanaClient,

--- a/source/perses/perses.go
+++ b/source/perses/perses.go
@@ -43,16 +43,19 @@ func NewCollector(db database.Database, cfg config.PersesCollector) (async.Simpl
 		}
 	}
 	logger := logrus.StandardLogger().WithField("collector", "perses")
+	url := cfg.HTTPClient.URL
+	if cfg.PublicURL != nil {
+		url = cfg.PublicURL
+	}
 	return &persesCollector{
-		SimpleTask:   nil,
+		persesURL:    url.String(),
 		persesClient: persesClientV1.NewWithClient(restClient).Dashboard(""),
 		metricUsageClient: &usageclient.Client{
 			DB:                db,
 			MetricUsageClient: metricUsageClient,
 			Logger:            logger,
 		},
-		persesURL: cfg.HTTPClient.URL.String(),
-		logger:    logger,
+		logger: logger,
 	}, nil
 }
 

--- a/source/rules/rules.go
+++ b/source/rules/rules.go
@@ -41,16 +41,21 @@ func NewCollector(db database.Database, cfg *config.RulesCollector) (async.Simpl
 		}
 	}
 	logger := logrus.StandardLogger().WithField("collector", "rules")
+	url := cfg.HTTPClient.URL.URL
+	if cfg.PublicURL != nil {
+		url = cfg.PublicURL.URL
+	}
+
 	return &rulesCollector{
+		promURL:    url.String(),
 		promClient: promClient,
 		metricUsageClient: &usageclient.Client{
 			DB:                db,
 			MetricUsageClient: metricUsageClient,
 			Logger:            logger,
 		},
-		promURL: cfg.HTTPClient.URL.String(),
-		logger:  logger,
-		retry:   cfg.RetryToGetRules,
+		logger: logger,
+		retry:  cfg.RetryToGetRules,
 	}, nil
 }
 


### PR DESCRIPTION
Close #71.
Allow overriding url used for fetching data with another url (`public_url`)

Example:
```
perses_collector:
  enable: true
  perses_client:
    url: "http://localhost:8080"
  public_url: "https://toto.com"
```

![image](https://github.com/user-attachments/assets/924865fb-5114-49bd-9e1d-15dce4edc774)
