### PR TITLE
[BREAKINGCHANGE] Use exact match as default search mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The tool provides an API endpoint, `/api/v1/metrics`, which returns the usage da
 
 You can use the following query parameter to filter the list returned:
 
-* **metric_name**: when used, it will trigger a fuzzy match search on the metric_name or exact/regex match if you enable it with `mode` parameter.
+* **metric_name**: when used, it will trigger a exact match search on the metric_name or fuzzy/regex match if you enable it with `mode` parameter.
 * **used**: when used, will return only the metric used or not (depending on if you set this boolean to true or to false). Leave it empty if you want both.
 * **mode**: when used change mode for filtering metrics. Three values are available:
   * **exact**: doing exact match (case sensitive) based on the metric name

--- a/source/metric/endpoint.go
+++ b/source/metric/endpoint.go
@@ -83,8 +83,8 @@ func isMetricMatching(metricName string, matchMode Mode, filter string) bool {
 		}
 		return re.MatchString(metricName)
 	default:
-		// if no match mode is specified, we assume fuzzy match
-		return fuzzy.Match(filter, metricName)
+		// if no match mode is specified, we assume exact match
+		return metricName == filter
 	}
 }
 


### PR DESCRIPTION
Proposing to use exact match as default search mode.

Fuzzy search show stuff that we may not need before the metric requested and regex can have issue with otel metrics that can contains dot or other special char.

I think default mode should be simple and returns what as been requested 😄

Following initial discussion: https://github.com/perses/metrics-usage/pull/69#discussion_r2050718283