### PR TITLE
feat: add concurrency option for the labels collector

### DIFF
--- a/config/collector.go
+++ b/config/collector.go
@@ -139,8 +139,9 @@ func (c *RulesCollector) Verify() error {
 }
 
 type LabelsCollector struct {
-	Enable bool           `yaml:"enable"`
-	Period model.Duration `yaml:"period,omitempty"`
+	Enable      bool           `yaml:"enable"`
+	Period      model.Duration `yaml:"period,omitempty"`
+	Concurrency int            `yaml:"concurrency,omitempty"`
 	// MetricUsageClient is a client to send the metrics usage to a remote metrics_usage server.
 	MetricUsageClient *HTTPClient `yaml:"metric_usage_client,omitempty"`
 	HTTPClient        HTTPClient  `yaml:"prometheus_client"`
@@ -153,11 +154,14 @@ func (c *LabelsCollector) Verify() error {
 	if c.Period <= 0 {
 		c.Period = model.Duration(defaultMetricCollectorPeriodDuration)
 	}
+	if c.Concurrency <= 0 {
+		c.Concurrency = 1
+	}
 	if c.HTTPClient.URL == nil {
-		return fmt.Errorf("missing Prometheus URL for the rules collector")
+		return fmt.Errorf("missing Prometheus URL for the labels collector")
 	}
 	if c.MetricUsageClient != nil && c.MetricUsageClient.URL == nil {
-		return fmt.Errorf("missing Metrics Usage URL for the rules collector")
+		return fmt.Errorf("missing Metrics Usage URL for the labels collector")
 	}
 	return nil
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -79,6 +79,7 @@ http_client: <HTTPClient config>
 ```yaml
 [ enable: <boolean> | default=false ]
 [ period: <duration> | default="12h" ]
+[ concurrency: <int> | default=1 ]
 
 # It is a client to send the labels to a remote metrics_usage server.
 [ metric_usage_client: <HTTPClient config> ]


### PR DESCRIPTION
This commit adds a new field `concurrency` to the labels collector. Because the collector needs to issue 1 HTTP request per discovered metric name, running multiple requests in parallel reduces the overall collection time. The default value is 1, making this an opt-in feature.