### PR TITLE
Implement predictable JSON output

### DIFF
--- a/pkg/api/v1/metric_usage_test.go
+++ b/pkg/api/v1/metric_usage_test.go
@@ -36,7 +36,7 @@ func TestJSONMarshalMetricUsage(t *testing.T) {
 			usage: &MetricUsage{
 				AlertRules: NewSet(RuleUsage{Name: "foo"}, RuleUsage{Name: "bar"}),
 			},
-			expectedJSON: `{"alertRules":[{"prom_link":"","group_name":"","name":"foo","expression":""},{"prom_link":"","group_name":"","name":"bar","expression":""}]}`,
+			expectedJSON: `{"alertRules":[{"prom_link":"","group_name":"","name":"bar","expression":""},{"prom_link":"","group_name":"","name":"foo","expression":""}]}`,
 		},
 	}
 	for _, test := range testSuite {


### PR DESCRIPTION
This change ensures that the JSON payload is generated in a predictable way. In particular it avoids random test failures because the expected output wasn't always matching.

I leaned towards using the `reflect`package because I found no other alternative that wouldn't imply importing another library (like https://pkg.go.dev/github.com/google/btree or https://pkg.go.dev/rsc.io/omap) and a big refactoring.