### PR TITLE
Fix db struct definition

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -71,7 +71,6 @@ func New(cfg config.Database) Database {
 }
 
 type db struct {
-	Database
 	// metrics is the list of metric name (as a key) associated with their usage based on the different collector activated.
 	// This struct is our "database".
 	metrics map[string]*v1.Metric
@@ -114,6 +113,8 @@ type db struct {
 	metricsMutex             sync.Mutex
 	partialMetricsUsageMutex sync.Mutex
 }
+
+var _ = Database(&db{})
 
 func (d *db) DeleteMetric(name string) bool {
 	d.metricsMutex.Lock()

--- a/source/grafana/grafana.go
+++ b/source/grafana/grafana.go
@@ -71,12 +71,13 @@ func NewCollector(db database.Database, cfg config.GrafanaCollector) (async.Simp
 }
 
 type grafanaCollector struct {
-	async.SimpleTask
 	metricUsageClient *usageclient.Client
 	grafanaURL        string
 	grafanaClient     *grafanaapi.GrafanaHTTPAPI
 	logger            *logrus.Entry
 }
+
+var _ async.SimpleTask = &grafanaCollector{}
 
 func (c *grafanaCollector) Execute(ctx context.Context, _ context.CancelFunc) error {
 	hits, err := c.collectAllDashboardUID(ctx)

--- a/source/labels/labels.go
+++ b/source/labels/labels.go
@@ -51,7 +51,6 @@ func NewCollector(db database.Database, cfg *config.LabelsCollector) (async.Simp
 }
 
 type labelCollector struct {
-	async.SimpleTask
 	promClient        v1.API
 	db                database.Database
 	metricUsageClient client.Client
@@ -59,6 +58,8 @@ type labelCollector struct {
 	concurrency       int
 	logger            *logrus.Entry
 }
+
+var _ async.SimpleTask = &labelCollector{}
 
 func (c *labelCollector) Execute(ctx context.Context, _ context.CancelFunc) error {
 	now := time.Now()

--- a/source/metric/metric.go
+++ b/source/metric/metric.go
@@ -40,12 +40,13 @@ func NewCollector(db database.Database, cfg config.MetricCollector) (async.Simpl
 }
 
 type metricCollector struct {
-	async.SimpleTask
 	client v1.API
 	db     database.Database
 	period model.Duration
 	logger *logrus.Entry
 }
+
+var _ async.SimpleTask = &metricCollector{}
 
 func (c *metricCollector) Execute(ctx context.Context, _ context.CancelFunc) error {
 	now := time.Now()

--- a/source/perses/perses.go
+++ b/source/perses/perses.go
@@ -60,12 +60,13 @@ func NewCollector(db database.Database, cfg config.PersesCollector) (async.Simpl
 }
 
 type persesCollector struct {
-	async.SimpleTask
 	persesClient      persesClientV1.DashboardInterface
 	metricUsageClient *usageclient.Client
 	persesURL         string
 	logger            *logrus.Entry
 }
+
+var _ async.SimpleTask = &persesCollector{}
 
 func (c *persesCollector) Execute(_ context.Context, _ context.CancelFunc) error {
 	dashboards, err := c.persesClient.List("")

--- a/source/rules/rules.go
+++ b/source/rules/rules.go
@@ -62,13 +62,14 @@ func NewCollector(db database.Database, cfg *config.RulesCollector) (async.Simpl
 }
 
 type rulesCollector struct {
-	async.SimpleTask
 	promClient        v1.API
 	metricUsageClient *usageclient.Client
 	promURL           string
 	logger            *logrus.Entry
 	retry             uint
 }
+
+var _ async.SimpleTask = &rulesCollector{}
 
 func (c *rulesCollector) Execute(ctx context.Context, _ context.CancelFunc) error {
 	result, err := c.getRules(ctx)


### PR DESCRIPTION
The `db` struct doesn't need to embed the `Database` interface. Instead we can verify that it satisfies the interface which would detect when the definition of the interface changes (new method for instance).